### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -23,7 +23,7 @@ class action_plugin_mediasyntax extends DokuWiki_Action_Plugin
     /**
      * register the eventhandlers
      */
-    function register(&$controller)
+    function register(Doku_Event_Handler $controller)
     {
         $controller->register_hook('TOOLBAR_DEFINE',
                           'AFTER',

--- a/syntax/bold.php
+++ b/syntax/bold.php
@@ -27,12 +27,12 @@ class syntax_plugin_mediasyntax_bold extends DokuWiki_Syntax_Plugin
     $this->Lexer->addSpecialPattern('\'\'\'',$mode,'plugin_mediasyntax_bold');
   }
  
-  function handle($match, $state, $pos, &$handler) 
+  function handle($match, $state, $pos, Doku_Handler $handler) 
   {
     return array($match, $state, $pos);
   }
  
-  function render($mode, &$renderer, $data) 
+  function render($mode, Doku_Renderer $renderer, $data) 
   {
     GLOBAL $bold;
     if($mode == 'xhtml')

--- a/syntax/codeblock.php
+++ b/syntax/codeblock.php
@@ -48,7 +48,7 @@ class syntax_plugin_mediasyntax_codeblock extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
         // $match2 = $match, but cut one blank at the beginning of every line.
         for ($i=1;$i<strlen($match);$i++) 
@@ -78,7 +78,7 @@ class syntax_plugin_mediasyntax_codeblock extends DokuWiki_Syntax_Plugin
 */
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
       if($mode == 'xhtml')
       {

--- a/syntax/header.php
+++ b/syntax/header.php
@@ -37,7 +37,7 @@ class syntax_plugin_mediasyntax_header extends DokuWiki_Syntax_Plugin
         );
     }
   
-    function handle($match, $state, $pos, &$handler)
+    function handle($match, $state, $pos, Doku_Handler $handler)
     {
         global $conf;
 
@@ -65,7 +65,7 @@ class syntax_plugin_mediasyntax_header extends DokuWiki_Syntax_Plugin
         return true;
     }
   
-    function render($mode, &$renderer, $data)
+    function render($mode, Doku_Renderer $renderer, $data)
     {
         return true;
     }

--- a/syntax/include.php
+++ b/syntax/include.php
@@ -33,7 +33,7 @@ class syntax_plugin_mediasyntax_include extends DokuWiki_Syntax_Plugin
         $this->Lexer->addSpecialPattern("{{.+?}}", $mode, 'plugin_mediasyntax_include');  
     } 
 
-    function handle($match, $state, $pos, &$handler) 
+    function handle($match, $state, $pos, Doku_Handler $handler) 
     {
 
         $match = substr($match, 2, -2); // strip markup
@@ -44,7 +44,7 @@ class syntax_plugin_mediasyntax_include extends DokuWiki_Syntax_Plugin
         return array($mode, $page, cleanID($sect), explode('&', $flags)); 
     }
 
-    function render($format, &$renderer, $data) 
+    function render($format, Doku_Renderer $renderer, $data) 
     {
         return false;
     }

--- a/syntax/italic.php
+++ b/syntax/italic.php
@@ -28,12 +28,12 @@ class syntax_plugin_mediasyntax_italic extends DokuWiki_Syntax_Plugin
     $this->Lexer->addSpecialPattern('\'\'',$mode,'plugin_mediasyntax_italic');
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     return array($match, $state, $pos);
   }
 
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
     GLOBAL $italic;
     if($mode == 'xhtml')

--- a/syntax/link.php
+++ b/syntax/link.php
@@ -40,7 +40,7 @@ class syntax_plugin_mediasyntax_link extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     if ($state == DOKU_LEXER_UNMATCHED)
     {
@@ -52,7 +52,7 @@ class syntax_plugin_mediasyntax_link extends DokuWiki_Syntax_Plugin
     return true;
   }
   
-  function render($mode, &$renderer, $data) { return true; }
+  function render($mode, Doku_Renderer $renderer, $data) { return true; }
 }
      
 //Setup VIM: ex: et ts=4 enc=utf-8 :

--- a/syntax/listblock.php
+++ b/syntax/listblock.php
@@ -51,7 +51,7 @@ class syntax_plugin_mediasyntax_listblock extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     switch ($state)
     {
@@ -77,7 +77,7 @@ class syntax_plugin_mediasyntax_listblock extends DokuWiki_Syntax_Plugin
     return true;
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
     return true;
   }

--- a/syntax/media.php
+++ b/syntax/media.php
@@ -36,7 +36,7 @@ class syntax_plugin_mediasyntax_media extends DokuWiki_Syntax_Plugin
     $this->Lexer->addSpecialPattern("\[\[File:.+?\]\]", $mode, 'plugin_mediasyntax_media');
   } 
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   // This first gets called with $state=1 and $match is the entryPattern that matched. 
   // Then it (the function handle) gets called with $state=3 and $match is the text
   // between the entryPattern and the exitPattern.
@@ -46,7 +46,7 @@ class syntax_plugin_mediasyntax_media extends DokuWiki_Syntax_Plugin
     return array($match, $state, $pos);
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   // $data is the return value of handle
   // $data[0] is always $match
   // $data[1] is always $state

--- a/syntax/nonbold.php
+++ b/syntax/nonbold.php
@@ -44,12 +44,12 @@ class syntax_plugin_mediasyntax_nonbold extends DokuWiki_Syntax_Plugin
     $this->Lexer->addSpecialPattern('\*\*',$mode,'plugin_mediasyntax_nonbold');
   }
 
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     return array($match, $state, $pos);
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
     if($mode == 'xhtml')
     {

--- a/syntax/nonitalic.php
+++ b/syntax/nonitalic.php
@@ -43,12 +43,12 @@ class syntax_plugin_mediasyntax_nonitalic extends DokuWiki_Syntax_Plugin
     $this->Lexer->addSpecialPattern('\/\/',$mode,'plugin_mediasyntax_nonitalic');
   }
 
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     return array($match, $state, $pos);
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
     // This is valid globally, not only for xhtml or so.
     $renderer->doc .= "//";

--- a/syntax/nonunderline.php
+++ b/syntax/nonunderline.php
@@ -43,12 +43,12 @@ class syntax_plugin_mediasyntax_nonunderline extends DokuWiki_Syntax_Plugin
     $this->Lexer->addSpecialPattern('__',$mode,'plugin_mediasyntax_nonunderline');
   }
 
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     return array($match, $state, $pos);
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
     // This is valid globally, not only for xhtml or so.
     $renderer->doc .= "__";

--- a/syntax/preblock.php
+++ b/syntax/preblock.php
@@ -40,7 +40,7 @@ class syntax_plugin_mediasyntax_preblock extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   // This first gets called with $state=1 and $match is the entryPattern that matched. 
   // Then it (the function handle) gets called with $state=3 and $match is the text
   // between the entryPattern and the exitPattern.
@@ -54,7 +54,7 @@ class syntax_plugin_mediasyntax_preblock extends DokuWiki_Syntax_Plugin
     return true;
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   {
     return true;
   }

--- a/syntax/redirect.php
+++ b/syntax/redirect.php
@@ -50,7 +50,7 @@ class syntax_plugin_mediasyntax_redirect extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     if ($state == DOKU_LEXER_UNMATCHED)
     {
@@ -58,7 +58,7 @@ class syntax_plugin_mediasyntax_redirect extends DokuWiki_Syntax_Plugin
     }
   }
   
-  function render($mode, &$renderer, $data) 
+  function render($mode, Doku_Renderer $renderer, $data) 
   {
     if (strlen($data)>0)
     {

--- a/syntax/span.php
+++ b/syntax/span.php
@@ -35,7 +35,7 @@ class syntax_plugin_mediasyntax_span extends DokuWiki_Syntax_Plugin
     );
   }
     
-  function handle($match, $state, $pos, &$handler) 
+  function handle($match, $state, $pos, Doku_Handler $handler) 
   // This first gets called with $state=1 and $match is the entryPattern that matched. 
   // Then it (the function handle) gets called with $state=3 and $match is the text
   // between the entryPattern and the exitPattern.
@@ -45,7 +45,7 @@ class syntax_plugin_mediasyntax_span extends DokuWiki_Syntax_Plugin
     return array($match, $state, $pos);
   }
  
-  function render($mode, &$renderer, $data) 
+  function render($mode, Doku_Renderer $renderer, $data) 
   {
     // $data is the return value of handle
     // $data[0] is always $match

--- a/syntax/teletyper.php
+++ b/syntax/teletyper.php
@@ -41,7 +41,7 @@ class syntax_plugin_mediasyntax_teletyper extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     dbglog("entering function ".__FUNCTION__.", match is $match, state is $state, pos is $pos");
     if ($state == DOKU_LEXER_UNMATCHED) return array($state,$match);
@@ -49,7 +49,7 @@ class syntax_plugin_mediasyntax_teletyper extends DokuWiki_Syntax_Plugin
     if ($state == DOKU_LEXER_EXIT) return array($state,$match);
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   // For understanding this see the very valuable code by Christopher Smith on http://www.dokuwiki.org/devel:syntax_plugins
   // $data is always what the function handle returned!
   {

--- a/syntax/underline.php
+++ b/syntax/underline.php
@@ -43,14 +43,14 @@ class syntax_plugin_mediasyntax_underline extends DokuWiki_Syntax_Plugin
     );
   }
   
-  function handle($match, $state, $pos, &$handler)
+  function handle($match, $state, $pos, Doku_Handler $handler)
   {
     if ($state == DOKU_LEXER_UNMATCHED) return array($state,$match);
     if ($state == DOKU_LEXER_ENTER) return array($state,$match);
     if ($state == DOKU_LEXER_EXIT) return array($state,$match);
   }
   
-  function render($mode, &$renderer, $data)
+  function render($mode, Doku_Renderer $renderer, $data)
   // For understanding this see the very valuable code by Christopher Smith on http://www.dokuwiki.org/devel:syntax_plugins
   // $data is always what the function handle returned!
   {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.