### PR TITLE
Fix conversion of multiple tables

### DIFF
--- a/tools/dokuwiki2mediawiki.php
+++ b/tools/dokuwiki2mediawiki.php
@@ -212,7 +212,7 @@ for ($argument=1;$argument<$argc;$argument++)
       //end display mediawiki table
 
       $headers="";
-      $cells="";
+      unset($cells);
       $row=0;
     } // endif have we left a table
 


### PR DESCRIPTION
When converting content with multiple tables, tables after the first fail to be processed correctly, resulting in the following fatal error:
```
Cannot use string offset as an array in .../dokuwiki2mediawiki.php:154
```
This happens because `$cells` is cleared to a string rather than being reset to `NULL`, so subsequent operations on `$cells` (e.g. `count`) then behave differently. The fix is to `unset` it rather than assigning to `""`.